### PR TITLE
Return ErrUnsuppConversion for all unsupported field types

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -561,7 +561,7 @@ func unmarshalVal(data []byte, bo binary.ByteOrder, ft FieldType, v reflect.Valu
 			return ErrUnsuppConversion{ft, typ}
 		}
 		v.SetInt(i64)
-	case reflect.Uint8, reflect.Int8, reflect.Float32, reflect.Float64:
+	default:
 		// If this was not handled at the top, we do not support
 		// converting other types to these types.
 		return ErrUnsuppConversion{ft, typ}


### PR DESCRIPTION
Unmarshaling a tiff into this structure will silently fail instead of returning [ErrUnsuppConversion](https://godoc.org/github.com/google/tiff#ErrUnsuppConversion). 

``` go
// Info contains the geotiff fields
type Info struct {
	ImageWidth  int `tiff:"field,tag=256"`
	ImageHeight int `tiff:"field,tag=257"`
}
```